### PR TITLE
feat: Introduce LocalLLM support via Ollama, small adjustments to fallback method for final answer

### DIFF
--- a/examples/ollama.ts
+++ b/examples/ollama.ts
@@ -2,7 +2,7 @@ import { OllamaModel,  ToolCallingAgent, tool } from 'smolagents.js';
 
 const getTimeTool = tool(
   {
-    name: 'get_Time',
+    name: 'get_time',
     description: 'Get the current time in a given city',
     inputs: {
       city: {
@@ -17,14 +17,29 @@ const getTimeTool = tool(
   }
 );
 
+const getWeatherTool = tool(
+  {
+    name: 'get_weather',
+    description: 'Get the weather for a given city',
+    inputs: {
+      city: {
+        type: 'string',
+        description: 'The city to get the weather for',
+      },
+    },
+    outputType: 'string',
+  },
+  async ({ city }: { city: string }): Promise<string> => {
+    return `The weather in ${city} is sunny`;
+  }
+);
+
 const agent = new ToolCallingAgent({
-  tools: [getTimeTool],
+  tools: [getTimeTool, getWeatherTool],
   model: new OllamaModel({
     modelId: 'mistral' 
   }),
-
+  maxSteps : 5,
 });
 
-await agent.run('What is the time in San Francisco?');
-
-
+await agent.run('What is the weather and time in İstanbul?');

--- a/examples/ollama.ts
+++ b/examples/ollama.ts
@@ -1,4 +1,4 @@
-import { LogLevel, OllamaModel,  ToolCallingAgent, tool } from 'smolagents.js';
+import { LogLevel, OllamaModel, ToolCallingAgent, tool } from 'smolagents.js';
 
 const getTimeTool = tool(
   {
@@ -29,11 +29,9 @@ const getWeatherTool = tool(
     },
     outputType: 'string',
   },
-  async ({ city }: { city: string })=> {
+  async ({ city }: { city: string }) => {
     return {
       observation: `The weather in ${city} is sunny`,
-      _requeue: 1,
-      arguments: { city: "New York"}
     };
   }
 );
@@ -41,10 +39,11 @@ const getWeatherTool = tool(
 const agent = new ToolCallingAgent({
   tools: [getTimeTool, getWeatherTool],
   model: new OllamaModel({
-    modelName: 'gemma3' 
+    modelName: 'gemma3',
   }),
-  maxSteps : 5,
+  maxSteps: 5,
   instructions: 'You are a helpful assistant.',
+  planningInterval: 1,
 });
 
 await agent.run('What is the weather and time in İstanbul?');

--- a/examples/ollama.ts
+++ b/examples/ollama.ts
@@ -1,4 +1,4 @@
-import { OllamaModel,  ToolCallingAgent, tool } from 'smolagents.js';
+import { LogLevel, OllamaModel,  ToolCallingAgent, tool } from 'smolagents.js';
 
 const getTimeTool = tool(
   {
@@ -29,17 +29,22 @@ const getWeatherTool = tool(
     },
     outputType: 'string',
   },
-  async ({ city }: { city: string }): Promise<string> => {
-    return `The weather in ${city} is sunny`;
+  async ({ city }: { city: string })=> {
+    return {
+      observation: `The weather in ${city} is sunny`,
+      _requeue: 1,
+      arguments: { city: "New York"}
+    };
   }
 );
 
 const agent = new ToolCallingAgent({
   tools: [getTimeTool, getWeatherTool],
   model: new OllamaModel({
-    modelName: 'mistral' 
+    modelName: 'gemma3' 
   }),
   maxSteps : 5,
+  instructions: 'You are a helpful assistant.',
 });
 
 await agent.run('What is the weather and time in İstanbul?');

--- a/examples/ollama.ts
+++ b/examples/ollama.ts
@@ -37,7 +37,7 @@ const getWeatherTool = tool(
 const agent = new ToolCallingAgent({
   tools: [getTimeTool, getWeatherTool],
   model: new OllamaModel({
-    modelId: 'mistral' 
+    modelName: 'mistral' 
   }),
   maxSteps : 5,
 });

--- a/examples/ollama.ts
+++ b/examples/ollama.ts
@@ -1,0 +1,30 @@
+import { OllamaModel,  ToolCallingAgent, tool } from 'smolagents.js';
+
+const getTimeTool = tool(
+  {
+    name: 'get_Time',
+    description: 'Get the current time in a given city',
+    inputs: {
+      city: {
+        type: 'string',
+        description: 'The city to get the time for',
+      },
+    },
+    outputType: 'string',
+  },
+  async ({ city }: { city: string }): Promise<string> => {
+    return `The current time in ${city} is 12:00 PM`;
+  }
+);
+
+const agent = new ToolCallingAgent({
+  tools: [getTimeTool],
+  model: new OllamaModel({
+    modelId: 'mistral' 
+  }),
+
+});
+
+await agent.run('What is the time in San Francisco?');
+
+

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "dist/types"
   ],
   "scripts": {
-    "build": "pnpm run clean && pnpm run build:esm && pnpm run build:types",
+    "build": "pnpm run clean && pnpm run build:esm && pnpm run build:types && pnpm run copy:prompts",
     "build:esm": "tsc --project tsconfig.esm.json && tsc-alias -p tsconfig.esm.json -f -fe .js",
     "build:types": "tsc --project tsconfig.types.json && tsc-alias -p tsconfig.types.json",
+    "copy:prompts": "mkdir -p dist/esm/prompts && cp src/prompts/*.yaml dist/esm/prompts/",
     "build:watch": "tsc --project tsconfig.esm.json --watch",
     "dev": "tsx src/index.ts",
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typecheck": "tsc --noEmit",
     "example:basic": "tsx examples/basic.ts",
     "example:stream": "tsx examples/stream.ts",
+    "example:ollama": "tsx examples/ollama.ts",
     "prepublishOnly": "pnpm run clean && pnpm run build"
   },
   "keywords": [

--- a/src/agents/agent-types/index.ts
+++ b/src/agents/agent-types/index.ts
@@ -42,7 +42,7 @@ function handleAgentOutputTypes(output: unknown, outputType?: string | null): Ag
   // idk what is gonna return here. but let'st throw error for now. I will check that later.
   // return output;
 
-  throw new Error('Unknown output type [TODO:]It will be fixed.');
+  return new AgentText(output as any);
 }
 
 export {

--- a/src/agents/multi-step-agent.ts
+++ b/src/agents/multi-step-agent.ts
@@ -498,6 +498,9 @@ export abstract class MultiStepAgent {
     // TODO: review this part.
     if (!returnedFinalAnswer && this.stepNumber === maxSteps + 1) {
       finalAnswer = await this._handleMaxStepsReached(task, images);
+      this.logger.log(chalk.hex('#FFD600')(`Final answer: ${finalAnswer}`), {
+              level: LogLevel.INFO,
+            });
       yield actionStep!;
     }
     // TODO: Review also this `handleAgentOutputTypes` function.
@@ -794,6 +797,7 @@ export abstract class MultiStepAgent {
    */
   protected async _provideFinalAnswer(task: string, images: AgentImage[]): Promise<ChatMessage> {
     // Start with the SYSTEM message and pre-message content
+
     const messages: ChatMessage[] = [
       new ChatMessage({
         role: MessageRole.SYSTEM,

--- a/src/agents/multi-step-agent.ts
+++ b/src/agents/multi-step-agent.ts
@@ -281,7 +281,7 @@ export abstract class MultiStepAgent {
     task: string,
     {
       stream = false,
-      reset = true,
+      reset = false,
       images,
       additionalArgs,
       maxSteps,
@@ -499,8 +499,8 @@ export abstract class MultiStepAgent {
     if (!returnedFinalAnswer && this.stepNumber === maxSteps + 1) {
       finalAnswer = await this._handleMaxStepsReached(task, images);
       this.logger.log(chalk.hex('#FFD600')(`Final answer: ${finalAnswer}`), {
-              level: LogLevel.INFO,
-            });
+        level: LogLevel.INFO,
+      });
       yield actionStep!;
     }
     // TODO: Review also this `handleAgentOutputTypes` function.

--- a/src/agents/tool-calling-agent.ts
+++ b/src/agents/tool-calling-agent.ts
@@ -369,6 +369,24 @@ function getJsonSchemaType(jsType: string): { type: string } {
 }
 
 export function validateToolArguments(tool: Tool, args: any): string | null {
+  // Special case for final_answer tool: allow both object and direct string format
+  if (tool.name === 'final_answer') {
+    if (typeof args === 'string') {
+      return null; // Direct string is valid for final_answer
+    }
+    if (typeof args === 'object' && args !== null && !Array.isArray(args)) {
+      // If it's an object, validate normally but more leniently
+      for (const key of Object.keys(args)) {
+        if (!(key in tool.inputs)) {
+          return `Argument ${key} is not in the tool's input schema.`;
+        }
+      }
+      return null;
+    }
+    // For final_answer, accept any reasonable input
+    return null;
+  }
+
   if (typeof args === 'object' && args !== null && !Array.isArray(args)) {
     for (const [key, value] of Object.entries(args)) {
       if (!(key in tool.inputs)) {

--- a/src/agents/tool-calling-agent.ts
+++ b/src/agents/tool-calling-agent.ts
@@ -220,19 +220,61 @@ export class ToolCallingAgent extends MultiStepAgent {
     const outputs: Record<string, ToolOutput> = {};
     const callList = Object.values(parallelCalls);
 
+    // Process calls. After each tool output we check whether the tool wants to be
+    // requeued. A tool can request requeueing by returning an object like:
+    //   { __requeue: true }            // requeue once with same args
+    //   { __requeue: N }               // requeue N times with same args
+    //   { __requeue: N, arguments: {} } // requeue N times with provided args
+    // When detected we yield a new ToolCall for the requeued invocation and
+    // immediately execute and yield its ToolOutput(s). This is not recursion of
+    // the model, it's forcing the agent to call the same tool again.
     if (callList.length === 1) {
       const toolCall = callList[0]!;
-      const toolOutput = await this.#processSingleToolCall(toolCall);
+      let toolOutput = await this.#processSingleToolCall(toolCall);
       outputs[toolCall.id] = toolOutput;
       yield toolOutput;
+
+      // Handle requeues signaled by tool output
+      if (typeof toolOutput.output === 'object' && toolOutput.output !== null && '__requeue' in toolOutput.output) {
+        const rq = (toolOutput.output as any)['__requeue'];
+        const count = typeof rq === 'number' ? rq : rq === true ? 1 : 0;
+        const newArgs = (toolOutput.output as any)['arguments'] ?? toolCall.arguments ?? {};
+        for (let i = 0; i < count; i++) {
+          const newId = `${toolCall.id}-requeue-${i + 1}-${Date.now()}`;
+          const newCall = new ToolCall(toolCall.name, newArgs, newId);
+          // yield the tool call so any listeners can see it
+          yield newCall;
+          const newOutput = await this.#processSingleToolCall(newCall);
+          outputs[newCall.id] = newOutput;
+          yield newOutput;
+          // allow chaining: if the requeued call itself requests further requeues,
+          // the outer loop will pick it up in the next iteration (but keep this
+          // implementation bounded by the requested count above).
+        }
+      }
     } else {
       const promises = callList.map(call =>
-        this.#processSingleToolCall(call).then(result => ({ id: call.id, result }))
+        this.#processSingleToolCall(call).then(result => ({ id: call.id, result, call }))
       );
       const resolved = await Promise.all(promises);
-      for (const { id, result } of resolved) {
+      for (const { id, result, call } of resolved) {
         outputs[id] = result;
         yield result;
+
+        // Handle requeues for each parallel result
+        if (typeof result.output === 'object' && result.output !== null && '__requeue' in result.output) {
+          const rq = (result.output as any)['__requeue'];
+          const count = typeof rq === 'number' ? rq : rq === true ? 1 : 0;
+          const newArgs = (result.output as any)['arguments'] ?? call.arguments ?? {};
+          for (let i = 0; i < count; i++) {
+            const newId = `${call.id}-requeue-${i + 1}-${Date.now()}`;
+            const newCall = new ToolCall(call.name, newArgs, newId);
+            yield newCall;
+            const newOutput = await this.#processSingleToolCall(newCall);
+            outputs[newCall.id] = newOutput;
+            yield newOutput;
+          }
+        }
       }
     }
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -14,3 +14,4 @@ export type {
 
 export { Model } from '@/models/base';
 export { OpenAIServerModel } from '@/models/api-models/openai';
+export { OllamaModel } from '@/models/local-models/ollama';

--- a/src/models/local-models/ollama.ts
+++ b/src/models/local-models/ollama.ts
@@ -78,7 +78,7 @@ export class OllamaModel extends Model {
   constructor({
     baseUrl = 'http://localhost:11434',
     modelName = 'mistral',
-    temperature = 0.2, // Default temperature is set to a low number to reduce errors via random texts
+    temperature = 0.1, // Default temperature is set to a low number to reduce errors via random texts
     top_p,
     num_predict,
     top_k,

--- a/src/models/local-models/ollama.ts
+++ b/src/models/local-models/ollama.ts
@@ -1,0 +1,540 @@
+import { Model } from '@/models/base';
+import { type ModelConfig } from '@/models';
+import { TokenUsage } from '@/monitoring';
+import { ChatMessage, ChatMessageStreamDelta } from '@/models/chat-message';
+import { MessageRole, type GenerateParams } from '@/models/types';
+import { AgentLogger, LogLevel } from '@/monitoring';
+
+export interface OllamaModelConfig extends ModelConfig {
+  baseUrl?: string; // e.g., 'http://localhost:11434'
+  modelName?: string; // Ollama model name (e.g., 'mistral', 'llama2', 'codellama')
+  temperature?: number; // Controls randomness (0-1). Lower values (0.1-0.3) are better for tool calling consistency
+  top_p?: number;
+  num_predict?: number;
+  top_k?: number;
+  repeat_penalty?: number;
+  seed?: number;
+  stop?: string[];
+}
+
+interface OllamaResponse {
+  model: string;
+  created_at: string;
+  message: {
+    role: string;
+    content: string;
+  };
+  done: boolean;
+  total_duration?: number;
+  load_duration?: number;
+  prompt_eval_count?: number;
+  prompt_eval_duration?: number;
+  eval_count?: number;
+  eval_duration?: number;
+}
+
+interface OllamaStreamResponse {
+  model: string;
+  created_at: string;
+  message?: {
+    role: string;
+    content: string;
+  };
+  done: boolean;
+  total_duration?: number;
+  load_duration?: number;
+  prompt_eval_count?: number;
+  prompt_eval_duration?: number;
+  eval_count?: number;
+  eval_duration?: number;
+}
+
+export class OllamaModel extends Model {
+  private baseUrl: string;
+  private modelName: string;
+  private temperature: number | undefined;
+  private top_p: number | undefined;
+  private num_predict: number | undefined;
+  private top_k: number | undefined;
+  private repeat_penalty: number | undefined;
+  private seed: number | undefined;
+  private stop: string[] | undefined;
+  private logger: AgentLogger;
+
+  /**
+   * Creates a new OllamaModel instance
+   *
+   * @param config - Configuration options for the Ollama model
+   * @param config.baseUrl - Ollama server URL (default: 'http://localhost:11434')
+   * @param config.modelName - Model name to use (default: 'mistral')
+   * @param config.temperature - Sampling temperature 0-1, lower values for more consistent tool calling (default: 0.2)
+   * @param config.top_p - Top-p sampling parameter
+   * @param config.num_predict - Maximum tokens to generate
+   * @param config.top_k - Top-k sampling parameter
+   * @param config.repeat_penalty - Repetition penalty
+   * @param config.seed - Random seed for reproducible outputs
+   * @param config.stop - Stop sequences to end generation
+   */
+  constructor({
+    baseUrl = 'http://localhost:11434',
+    modelName = 'mistral',
+    temperature = 0.2, // Default temperature is set to a low number to reduce errors via random texts
+    top_p,
+    num_predict,
+    top_k,
+    repeat_penalty,
+    seed,
+    stop,
+    ...rest
+  }: OllamaModelConfig) {
+    super({ modelId: modelName, ...rest });
+
+    this.baseUrl = baseUrl;
+    this.modelName = modelName;
+    this.temperature = temperature;
+    this.top_p = top_p;
+    this.num_predict = num_predict;
+    this.top_k = top_k;
+    this.repeat_penalty = repeat_penalty;
+    this.seed = seed;
+    this.stop = stop;
+    this.logger = new AgentLogger(LogLevel.INFO);
+  }
+
+  /**
+   * Transform SmolaAgents messages to Ollama format and handle tool calling
+   * Converts message formats and adds system prompts for tool calling when tools are available.
+   * Ensures proper formatting for tool execution by providing clear JSON examples.
+   *
+   * @param messages - Array of chat messages to transform
+   * @param toolsToCallFrom - Optional array of available tools for tool calling
+   * @returns Transformed messages in Ollama format
+   */
+  public transformMessages(messages: any[], toolsToCallFrom?: any[]): any[] {
+    const transformedMessages = messages.map(msg => ({
+      role:
+        msg.role === MessageRole.ASSISTANT
+          ? 'assistant'
+          : msg.role === MessageRole.USER
+            ? 'user'
+            : msg.role === MessageRole.SYSTEM
+              ? 'system'
+              : 'user',
+      content:
+        typeof msg.content === 'string'
+          ? msg.content
+          : Array.isArray(msg.content)
+            ? msg.content.map((c: any) => c.text || c).join(' ')
+            : String(msg.content),
+    }));
+
+    // If tools are available, add system message with tool calling instructions
+    if (toolsToCallFrom && toolsToCallFrom.length > 0) {
+      const toolDescriptions = toolsToCallFrom
+        .map(
+          tool =>
+            `- ${tool.function?.name || tool.name}: ${tool.function?.description || tool.description}`
+        )
+        .join('\n');
+
+
+        //TODO: Will take this to a .yaml like file with betterly written prompt or use default system prompt
+        // We need another system message aside from agent as ollama does not natively support tool calling similar to the way other models do.
+      const toolCallSystemMessage = {
+        role: 'system',
+        content: `You are an AI assistant with access to the following tools:
+
+          ${toolDescriptions}
+
+          IMPORTANT RULES:
+          1. Call ONLY ONE tool at a time
+          2. When you need to use a tool, respond with EXACTLY this JSON format:
+          {
+            "name": "tool_name",
+            "arguments": {"param1": "value1", "param2": "value2"}
+          }
+
+          3. Do NOT include multiple tool calls in one response
+          4. Do NOT add any text before or after the JSON
+          5. For regular conversation (non-tool responses), answer normally without JSON
+
+          Example good tool call:
+          {
+            "name": "get_weather",
+            "arguments": {"city": "Paris"}
+          }
+
+          Example BAD (multiple tools):
+          {
+            "name": "get_weather",
+            "arguments": {"city": "Paris"}
+          },
+          {
+            "name": "get_time", 
+            "arguments": {"city": "Paris"}
+          }
+
+          If you need multiple tools, the system will call you again after the first tool completes.`,
+      };
+
+      // Insert the system message at the beginning (after any existing system messages)
+      const firstNonSystemIndex = transformedMessages.findIndex(msg => msg.role !== 'system');
+      if (firstNonSystemIndex === -1) {
+        transformedMessages.push(toolCallSystemMessage);
+      } else {
+        transformedMessages.splice(firstNonSystemIndex, 0, toolCallSystemMessage);
+      }
+    }
+
+    return transformedMessages;
+  }
+
+  /**
+   * Create the request options for Ollama API
+   *
+   * Builds configuration object with sampling parameters for model generation.
+   * Only includes parameters that have been explicitly set to avoid sending undefined values.
+   *
+   * @returns Configuration object for Ollama API requests
+   */
+  private createRequestOptions(): Record<string, any> {
+    const options: Record<string, any> = {};
+    
+    if (this.temperature !== undefined) options['temperature'] = this.temperature;
+    if (this.top_p !== undefined) options['top_p'] = this.top_p;
+    if (this.num_predict !== undefined) options['num_predict'] = this.num_predict;
+    if (this.top_k !== undefined) options['top_k'] = this.top_k;
+    if (this.repeat_penalty !== undefined) options['repeat_penalty'] = this.repeat_penalty;
+    if (this.seed !== undefined) options['seed'] = this.seed;
+    if (this.stop !== undefined) options['stop'] = this.stop;
+
+    return options;
+  }
+
+  /**
+   * Check if Ollama server is running and model is available
+   *
+   * Queries the Ollama server to verify connectivity and that the specified model
+   * is available locally. Used for health checks before making generation requests.
+   *
+   * @returns Promise that resolves to true if server is healthy and model is available
+   */
+  async checkHealth(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/tags`);
+      if (!response.ok) return false;
+
+      const data = await response.json();
+      const models = data.models || [];
+      return models.some((model: any) => model.name.includes(this.modelName));
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
+   * Pull a model if it's not available locally
+   *
+   * Downloads the specified model from Ollama's model registry if it's not already
+   * available locally. This is automatically called when a model is not found during
+   * generation requests.
+   *
+   * @throws Error if the model cannot be pulled or the request fails
+   */
+  async pullModel(): Promise<void> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/pull`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: this.modelName }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to pull model ${this.modelName}: ${response.statusText}`);
+      }
+
+      // Read the stream to completion
+      const reader = response.body?.getReader();
+      if (reader) {
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      }
+    } catch (error) {
+      throw new Error(`Failed to pull Ollama model: ${error}`);
+    }
+  }
+
+  override async generate(params: GenerateParams): Promise<ChatMessage> {
+    // Check if server is running and model is available
+    const isHealthy = await this.checkHealth();
+    if (!isHealthy) {
+      this.logger.console.log(
+        LogLevel.INFO,
+        `Ollama model ${this.modelName} not found locally. Attempting to pull...`
+      );
+      await this.pullModel();
+    }
+
+    const completionParams = await this.prepareCompletionParams({
+      messages: params.messages,
+      stopSequences: params.stopSequences ?? null,
+      responseFormat: params.responseFormat ?? null,
+      toolsToCallFrom: params.toolsToCallFrom ?? null,
+      modelId: this.modelId ?? this.modelName,
+    });
+
+    const transformedMessages = this.transformMessages(
+      completionParams['messages'],
+      completionParams['tools']
+    );
+    const requestOptions = this.createRequestOptions();
+
+    try {
+      const response = await fetch(`${this.baseUrl}/api/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: this.modelName,
+          messages: transformedMessages,
+          stream: false,
+          options: requestOptions,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`);
+      }
+
+      const data: OllamaResponse = await response.json();
+
+      // Extract token usage information if available
+      const inputTokens = data.prompt_eval_count || 0;
+      const outputTokens = data.eval_count || 0;
+
+      // Update token counts for monitoring
+      this._lastInputTokenCount = inputTokens;
+      this._lastOutputTokenCount = outputTokens;
+
+      return new ChatMessage({
+        role: MessageRole.ASSISTANT,
+        content: data.message.content,
+        raw: data,
+        tokenUsage: new TokenUsage(inputTokens, outputTokens),
+      });
+    } catch (error) {
+      throw new Error(`Ollama generation failed: ${error}`);
+    }
+  }
+
+  /**
+   * Override parseToolCalls to provide better error handling for Ollama
+   *
+   * Implements robust JSON extraction from mixed-content responses that Ollama models
+   * often generate. Uses brace counting to properly extract complete JSON objects
+   * and provides detailed error reporting for debugging tool calling issues.
+   *
+   * @param message - The chat message containing potential tool call JSON
+   * @returns Parsed message with tool call information
+   * @throws Error with detailed debugging information if parsing fails
+   */
+  override parseToolCalls(message: ChatMessage): ChatMessage {
+    const content = typeof message.content === 'string' ? message.content : String(message.content);
+
+    /**
+     * Extract JSON tool call from mixed text content
+     * Uses brace counting to handle nested objects properly
+     */
+    const extractToolCallJson = (text: string): string | null => {
+      // Find the start of JSON object
+      const startIndex = text.indexOf('{');
+      if (startIndex === -1) return null;
+
+      let braceCount = 0;
+      let endIndex = startIndex;
+
+      // Count braces to find the complete JSON object
+      for (let i = startIndex; i < text.length; i++) {
+        if (text[i] === '{') braceCount++;
+        if (text[i] === '}') braceCount--;
+
+        if (braceCount === 0) {
+          endIndex = i;
+          break;
+        }
+      }
+
+      if (braceCount === 0) {
+        const jsonCandidate = text.substring(startIndex, endIndex + 1);
+        // Verify it contains required tool call fields
+        if (jsonCandidate.includes('"name"') && jsonCandidate.includes('"arguments"')) {
+          return jsonCandidate;
+        }
+      }
+
+      return null;
+    };
+
+    const extractedJson = extractToolCallJson(content);
+
+    if (extractedJson) {
+      this.logger.console.log(LogLevel.DEBUG, `Extracted tool call JSON: ${extractedJson}`);
+
+      // Create a new message with cleaned content
+      const cleanedMessage = new ChatMessage({
+        role: message.role,
+        content: extractedJson,
+        raw: message.raw,
+        tokenUsage: message.tokenUsage,
+      });
+
+      try {
+        return super.parseToolCalls(cleanedMessage);
+      } catch (parseError) {
+        this.logger.console.log(LogLevel.ERROR, `Failed to parse extracted JSON: ${parseError}`);
+        this.logger.console.log(LogLevel.DEBUG, `Extracted content was: ${extractedJson}`);
+      }
+    }
+
+    // If JSON extraction failed, try the original parsing
+    try {
+      return super.parseToolCalls(message);
+    } catch (error) {
+      // If tool call parsing fails, provide a helpful error message
+      this.logger.console.log(
+        LogLevel.ERROR,
+        `Ollama tool call parsing failed. Raw response: ${content.substring(0, 300)}`
+      );
+      this.logger.console.log(
+        LogLevel.INFO,
+        'Tip: Ollama models need clear instruction to output ONLY JSON format for tool calls.'
+      );
+
+      // Try to extract any JSON-like content and suggest fixes
+      if (content.includes('{') && content.includes('}')) {
+        this.logger.console.log(
+          LogLevel.DEBUG,
+          'Found JSON-like content but parsing failed. The model may be adding extra text.'
+        );
+      } else {
+        this.logger.console.log(
+          LogLevel.DEBUG,
+          'No JSON detected. The model may not understand tool calling format.'
+        );
+      }
+
+      throw new Error(
+        `Ollama tool call parsing failed. The model response was: "${content.substring(0, 200)}...". ` +
+          'Make sure your Ollama model supports function calling or try a different model like mistral:instruct or llama3.'
+      );
+    }
+  }
+
+  /**
+   * Generate streaming response from Ollama model
+   *
+   * Provides real-time streaming of model responses with automatic model pulling
+   * if the model is not available locally. Supports the same parameters as generate()
+   * but returns an async generator for progressive response handling.
+   *
+   * @param params - Generation parameters including messages and tools
+   * @yields ChatMessageStreamDelta objects with incremental response content
+   */
+  override async *generateStream(params: GenerateParams): AsyncGenerator<ChatMessageStreamDelta> {
+    // Check if server is running and model is available
+    const isHealthy = await this.checkHealth();
+    if (!isHealthy) {
+      this.logger.console.log(
+        LogLevel.INFO,
+        `Ollama model ${this.modelName} not found locally. Attempting to pull...`
+      );
+      await this.pullModel();
+    }
+
+    const completionParams = await this.prepareCompletionParams({
+      messages: params.messages,
+      stopSequences: params.stopSequences ?? null,
+      responseFormat: params.responseFormat ?? null,
+      toolsToCallFrom: params.toolsToCallFrom ?? null,
+      modelId: this.modelId ?? this.modelName,
+    });
+
+    const transformedMessages = this.transformMessages(
+      completionParams['messages'],
+      completionParams['tools']
+    );
+    const requestOptions = this.createRequestOptions();
+
+    try {
+      const response = await fetch(`${this.baseUrl}/api/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: this.modelName,
+          messages: transformedMessages,
+          stream: true,
+          options: requestOptions,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error('Failed to get response stream reader');
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() || '';
+
+          for (const line of lines) {
+            if (line.trim()) {
+              try {
+                const data: OllamaStreamResponse = JSON.parse(line);
+
+                if (data.message?.content) {
+                  yield new ChatMessageStreamDelta({
+                    content: data.message.content,
+                  });
+                }
+
+                // Handle final response with token usage
+                if (data.done && data.eval_count) {
+                  this._lastInputTokenCount = data.prompt_eval_count || 0;
+                  this._lastOutputTokenCount = data.eval_count || 0;
+
+                  yield new ChatMessageStreamDelta({
+                    content: '',
+                    tokenUsage: new TokenUsage(
+                      this._lastInputTokenCount,
+                      this._lastOutputTokenCount
+                    ),
+                  });
+                }
+              } catch (parseError) {
+                console.warn('Failed to parse Ollama stream response:', line);
+              }
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    } catch (error) {
+      throw new Error(`Ollama streaming failed: ${error}`);
+    }
+  }
+}

--- a/src/models/local-models/ollama.ts
+++ b/src/models/local-models/ollama.ts
@@ -137,44 +137,13 @@ export class OllamaModel extends Model {
         )
         .join('\n');
 
-
-        //TODO: Will take this to a .yaml like file with betterly written prompt or use default system prompt
-        // We need another system message aside from agent as ollama does not natively support tool calling similar to the way other models do.
+      //TODO: Will take this to a .yaml like file with betterly written prompt or use default system prompt
+      // We need another system message aside from agent as ollama does not natively support tool calling similar to the way other models do.
       const toolCallSystemMessage = {
         role: 'system',
         content: `You are an AI assistant with access to the following tools:
 
-          ${toolDescriptions}
-
-          IMPORTANT RULES:
-          1. Call ONLY ONE tool at a time
-          2. When you need to use a tool, respond with EXACTLY this JSON format:
-          {
-            "name": "tool_name",
-            "arguments": {"param1": "value1", "param2": "value2"}
-          }
-
-          3. Do NOT include multiple tool calls in one response
-          4. Do NOT add any text before or after the JSON
-          5. For regular conversation (non-tool responses), answer normally without JSON
-
-          Example good tool call:
-          {
-            "name": "get_weather",
-            "arguments": {"city": "Paris"}
-          }
-
-          Example BAD (multiple tools):
-          {
-            "name": "get_weather",
-            "arguments": {"city": "Paris"}
-          },
-          {
-            "name": "get_time", 
-            "arguments": {"city": "Paris"}
-          }
-
-          If you need multiple tools, the system will call you again after the first tool completes.`,
+          ${toolDescriptions}`,
       };
 
       // Insert the system message at the beginning (after any existing system messages)
@@ -199,7 +168,7 @@ export class OllamaModel extends Model {
    */
   private createRequestOptions(): Record<string, any> {
     const options: Record<string, any> = {};
-    
+
     if (this.temperature !== undefined) options['temperature'] = this.temperature;
     if (this.top_p !== undefined) options['top_p'] = this.top_p;
     if (this.num_predict !== undefined) options['num_predict'] = this.num_predict;

--- a/src/prompts/toolcalling_agent.yaml
+++ b/src/prompts/toolcalling_agent.yaml
@@ -236,7 +236,9 @@ managed_agent:
     {{final_answer}}
 final_answer:
   pre_messages: |-
-    An agent tried to answer a user query but it got stuck and failed to do so. You are tasked with providing an answer instead. Here is the agent's memory:
+    CRITICAL ERROR: An agent has failed to complete a task and got stuck in an infinite loop despite having all necessary information. This is a severe execution failure that needs human intervention. Below is the complete agent memory which clearly shows all interactions and information:
   post_messages: |-
-    Based on the above, please provide an answer to the following user task:
+    ATTENTION: The agent clearly had all required information to solve this problem but failed to reach a conclusion. This is an AI execution failure.
+    
+    As the backup system, you MUST now provide a direct answer to the following task using ONLY the information already present in the above memory. Do not apologize for the failure - just solve the problem:
     {{task}}

--- a/src/prompts/toolcalling_agent.yaml
+++ b/src/prompts/toolcalling_agent.yaml
@@ -106,8 +106,8 @@ system_prompt: |-
   {%- endfor %}
   {%- endif %}
 
-  {%- if custom_instructions %}
-  {{custom_instructions}}
+  {%- if customInstructions %}
+  {{customInstructions}}
   {%- endif %}
 
   Here are the rules you should always follow to solve your task:

--- a/src/prompts/toolcalling_agent.yaml
+++ b/src/prompts/toolcalling_agent.yaml
@@ -90,21 +90,11 @@ system_prompt: |-
   }
 
   Above example were using notional tools that might not exist for you. You only have access to these tools:
-  {%- for tool in tools %}
-  - {{ toToolCallingPrompt(tool) }}
-  {%- endfor %}
-
-  {%- if managedAgents | list %}
-  You can also give tasks to team members.
-  Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
-  You can also include any relevant variables or context using the 'additional_args' argument.
-  Here is a list of the team members that you can call:
-  {%- for agent in managedAgents %}
-  - {{ agent.name }}: {{ agent.description }}
-    - Takes inputs: {{agent.inputs}}
-    - Returns an output of type: {{agent.output_type}}
-  {%- endfor %}
+  {%- if toolPrompt %}
+  {{toolPrompt}}
   {%- endif %}
+
+
 
   {%- if customInstructions %}
   {{customInstructions}}
@@ -122,42 +112,31 @@ planning:
     You are a world expert at analyzing a situation to derive facts, and plan accordingly towards solving a task.
     Below I will present you a task. You will need to 1. build a survey of facts known or needed to solve the task, then 2. make a plan of action to solve the task.
 
+    IMPORTANT CONSTRAINT: You MUST ONLY use the tools explicitly listed in the "You can leverage these tools:" block that will be printed below (the {{toolPrompt}} section). Do NOT assume any other tools exist (for example: web_search, external APIs, or other notional tools). Any plan step that requires a tool not present in that list is invalid and must not be included. If a needed fact cannot be obtained with the available tools, do NOT invent external tool calls — instead list the missing dependency and propose an alternative using only available tools (internal reasoning, file inspection, user prompts, or requesting a human to provide the missing input).
+
     ## 1. Facts survey
     You will build a comprehensive preparatory survey of which facts we have at our disposal and which ones we still need.
     These "facts" will typically be specific names, dates, values, etc. Your answer should use the below headings:
     ### 1.1. Facts given in the task
     List here the specific facts given in the task that could help you (there might be nothing here).
 
-    ### 1.2. Facts to look up
-    List here any facts that we may need to look up.
-    Also list where to find each of these, for instance a website, a file... - maybe the task contains some sources that you should re-use here.
+    ### 1.2. Facts to look up (only via available tools)
+    List here any facts that we may need to look up and explicitly indicate which available tool (from the provided tool list) you will use to obtain each fact. If no available tool can obtain a needed fact, mark it as "UNAVAILABLE" and describe how you will handle it (derive, estimate, or request human input).
 
     ### 1.3. Facts to derive
     List here anything that we want to derive from the above by logical reasoning, for instance computation or simulation.
 
-    Don't make any assumptions. For each item, provide a thorough reasoning. Do not add anything else on top of three headings above.
+    Don't make any assumptions. For each item, provide a thorough reasoning. Do not add anything else on top of the three headings above.
 
     ## 2. Plan
     Then for the given task, develop a step-by-step high-level plan taking into account the above inputs and list of facts.
-    This plan should involve individual tasks based on the available tools, that if executed correctly will yield the correct answer.
+    This plan MUST only include steps that can be executed using the available tools listed below. For each step, explicitly name which available tool (from the provided tool list) will be used, or mark the step as "pure reasoning" if no tool is required. If a logical step requires a tool not in the list, do not include it; instead include a contingency step that requests the missing data or proposes a workaround using available tools or human input.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 
     You can leverage these tools:
-    {%- for tool in tools %}
-    - {{ toToolCallingPrompt(tool) }}
-    {%- endfor %}
-
-    {%- if managedAgents | list %}
-    You can also give tasks to team members.
-    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
-    You can also include any relevant variables or context using the 'additional_args' argument.
-    Here is a list of the team members that you can call:
-    {%- for agent in managedAgents %}
-    - {{ agent.name }}: {{ agent.description }}
-      - Takes inputs: {{agent.inputs}}
-      - Returns an output of type: {{agent.output_type}}
-    {%- endfor %}
+    {%- if toolPrompt %}
+    {{toolPrompt}}
     {%- endif %}
 
     ---
@@ -174,43 +153,27 @@ planning:
     ```
 
     Below you will find a history of attempts made to solve this task.
-    You will first have to produce a survey of known and unknown facts, then propose a step-by-step high-level plan to solve the task.
-    If the previous tries so far have met some success, your updated plan can build on these results.
-    If you are stalled, you can make a completely new plan starting from scratch.
-
-    Find the task and history below:
+    IMPORTANT CONSTRAINT: Any new or updated plan MUST only rely on tools explicitly listed in the "You can leverage these tools:" block below. Do NOT introduce or plan for tools that are not present in that list (no web search, no external APIs, no notional tools). If previous attempts used unavailable tools, treat those steps as failed dependencies and propose alternatives that use only available tools or request explicit human-provided data.
   update_plan_post_messages: |-
-    Now write your updated facts below, taking into account the above history:
+    Now write your updated facts below, taking into account the above history and the tool availability constraint:
     ## 1. Updated facts survey
     ### 1.1. Facts given in the task
     ### 1.2. Facts that we have learned
-    ### 1.3. Facts still to look up
+    ### 1.3. Facts still to look up (indicate which available tool will be used; mark UNAVAILABLE if none)
     ### 1.4. Facts still to derive
 
     Then write a step-by-step high-level plan to solve the task above.
     ## 2. Plan
-    ### 2. 1. ...
+    ### 2.1. ...
     Etc.
-    This plan should involve individual tasks based on the available tools, that if executed correctly will yield the correct answer.
+    This plan MUST only include steps that can be executed using the tools listed below. For each step, explicitly state which available tool (from the provided list) will be used or mark it as "pure reasoning" if no tool is required. If a required fact cannot be obtained with the available tools, include a mandatory step to request that fact from a human or provide a safe fallback derivation.
     Beware that you have {remaining_steps} steps remaining.
     Do not skip steps, do not add any superfluous steps. Only write the high-level plan, DO NOT DETAIL INDIVIDUAL TOOL CALLS.
     After writing the final step of the plan, write the '<end_plan>' tag and stop there.
 
     You can leverage these tools:
-    {%- for tool in tools %}
-    - {{ toToolCallingPrompt(tool) }}
-    {%- endfor %}
-
-    {%- if managedAgents | list %}
-    You can also give tasks to team members.
-    Calling a team member works similarly to calling a tool: provide the task description as the 'task' argument. Since this team member is a real human, be as detailed and verbose as necessary in your task description.
-    You can also include any relevant variables or context using the 'additional_args' argument.
-    Here is a list of the team members that you can call:
-    {%- for agent in managedAgents %}
-    - {{ agent.name }}: {{ agent.description }}
-      - Takes inputs: {{agent.inputs}}
-      - Returns an output of type: {{agent.output_type}}
-    {%- endfor %}
+    {%- if toolPrompt %}
+    {{toolPrompt}}
     {%- endif %}
 
     Now write your new plan below.
@@ -239,6 +202,6 @@ final_answer:
     CRITICAL ERROR: An agent has failed to complete a task and got stuck in an infinite loop despite having all necessary information. This is a severe execution failure that needs human intervention. Below is the complete agent memory which clearly shows all interactions and information:
   post_messages: |-
     ATTENTION: The agent clearly had all required information to solve this problem but failed to reach a conclusion. This is an AI execution failure.
-    
+
     As the backup system, you MUST now provide a direct answer to the following task using ONLY the information already present in the above memory. Do not apologize for the failure - just solve the problem:
     {{task}}

--- a/src/tools/default-tools/final-answer.ts
+++ b/src/tools/default-tools/final-answer.ts
@@ -9,6 +9,7 @@ export class FinalAnswerTool extends Tool {
         answer: {
           type: 'any',
           description: 'The final answer to the problem',
+          nullable: true,
         },
       },
       outputType: 'any',
@@ -16,6 +17,14 @@ export class FinalAnswerTool extends Tool {
   }
 
   override execute(input: any): any {
-    return input['answer'];
+    // Handle both {"answer": "..."} and direct string formats
+    if (typeof input === 'string') {
+      return input;
+    }
+    if (input && typeof input === 'object' && 'answer' in input) {
+      return input['answer'];
+    }
+    // Fallback: return the input as-is
+    return input;
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -115,6 +115,13 @@ function populateTemplate(
   });
 
   env.addGlobal('toToolCallingPrompt', toToolCallingPrompt);
+  var toolPrompt = '';
+  for (var tool in rawContext.tools) {
+    const currentTool = rawContext.tools[tool];
+    if (currentTool) {
+      toolPrompt += toToolCallingPrompt(currentTool);
+    }
+  }
 
   const context = {
     tools: rawContext.tools ?? {},
@@ -124,6 +131,7 @@ function populateTemplate(
     remainingSteps: rawContext.remainingSteps,
     name: rawContext.name,
     finalAnswer: rawContext.finalAnswer,
+    toolPrompt: toolPrompt,
   };
 
   return env.renderString(template, context);


### PR DESCRIPTION
This pull request introduces a new example demonstrating how to use the `OllamaModel` with tool calling agents, adds support for running this example, and improves logging and error messaging for agent execution failures. The changes are mainly focused on expanding functionality and improving diagnostics for multi-step agents.

### New Model Integration

#### OllamaModel Implementation
* New model class for interfacing with locally running Ollama instances
* Instead of base  `ApiModel` class it extends  `Model` as it does not require any ratelimiting or api credentials
* May create base class for local models in the future depending on the performance of localllm  
* Seamless integration as drop-in replacement for other model providers in existing agent workflows
* Local model support enables running agents completely offline with models like Gemma, Llama, Mistral, etc.
* Flexible configuration with simple modelId parameter to specify which Ollama model to use

#### Model Capabilities
* Full compatibility with the existing tool calling agent infrastructure
* Works with complex agent workflows requiring multiple tool invocations
* Performance optimization designed to work efficiently with local model constraints

#### Developer Benefits
* Privacy-first approach by keeping sensitive data local with self-hosted models
* Cost-effective solution with no API costs for model inference
* Customization support for fine-tuned or specialized models available through Ollama
* Offline capability to run agents without internet connectivity


### Agent diagnostics and error handling

* Added logger to `_provideFinalAnswer` method and changed the prompt to make LLM to give correct final answer.